### PR TITLE
Update SendReplyService

### DIFF
--- a/src/ENode.EQueue/SendReplyService.cs
+++ b/src/ENode.EQueue/SendReplyService.cs
@@ -91,6 +91,7 @@ namespace ENode.EQueue
             {
                 if (_remotingClientDict.TryRemove(pair.Key, out SocketRemotingClient removed))
                 {
+                    removed.Shutdown();
                     _logger.InfoFormat("Removed disconnected command remoting client, remotingAddress: {0}", pair.Key);
                 }
             }


### PR DESCRIPTION
*)CommandResultProcessor挂起时，SendReplyService里的SocketRemotingClient遗漏需要Shutdown停止ReconnectServer()