### PR TITLE
修改同步方法中调用异步方法的bug

### DIFF
--- a/src/ENode.EQueue/Command/CommandConsumer.cs
+++ b/src/ENode.EQueue/Command/CommandConsumer.cs
@@ -77,7 +77,7 @@ namespace ENode.EQueue
             var commandExecuteContext = new CommandExecuteContext(_repository, _aggregateStorage, queueMessage, context, commandMessage, _sendReplyService);
             commandItems["CommandReplyAddress"] = commandMessage.ReplyAddress;
             _logger.DebugFormat("ENode command message received, messageId: {0}, aggregateRootId: {1}", command.Id, command.AggregateRootId);
-            _commandProcessor.Process(new ProcessingCommand(command, commandExecuteContext, commandItems));
+            _commandProcessor.ProcessAsync(new ProcessingCommand(command, commandExecuteContext, commandItems));
         }
 
         class CommandExecuteContext : ICommandExecuteContext

--- a/src/ENode.EQueue/DomainEvent/DomainEventConsumer.cs
+++ b/src/ENode.EQueue/DomainEvent/DomainEventConsumer.cs
@@ -72,7 +72,7 @@ namespace ENode.EQueue
             var processContext = new DomainEventStreamProcessContext(this, domainEventStreamMessage, queueMessage, context);
             var processingMessage = new ProcessingEvent(domainEventStreamMessage, processContext);
             _logger.DebugFormat("ENode event stream message received, messageId: {0}, aggregateRootId: {1}, aggregateRootType: {2}, version: {3}", domainEventStreamMessage.Id, domainEventStreamMessage.AggregateRootId, domainEventStreamMessage.AggregateRootTypeName, domainEventStreamMessage.Version);
-            _messageProcessor.Process(processingMessage);
+            _messageProcessor.ProcessAsync(processingMessage);
         }
 
         private DomainEventStreamMessage ConvertToDomainEventStream(EventStreamMessage message)

--- a/src/ENode.Tests/TestClasses/CommandAndEventServiceTest.cs
+++ b/src/ENode.Tests/TestClasses/CommandAndEventServiceTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using ECommon.Components;
 using ECommon.IO;
 using ECommon.Utilities;
@@ -639,7 +640,7 @@ namespace ENode.Tests
             HandlerTypes.Clear();
         }
         [Test]
-        public void sequence_domain_event_process_test()
+        public async Task sequence_domain_event_process_test()
         {
             var processor = ObjectContainer.Resolve<IProcessingEventProcessor>();
 
@@ -658,9 +659,9 @@ namespace ENode.Tests
             var waitHandle = new ManualResetEvent(false);
             var versionList = new List<int>();
 
-            processor.Process(new ProcessingEvent(message1, new DomainEventStreamProcessContext(message1, waitHandle, versionList)));
-            processor.Process(new ProcessingEvent(message3, new DomainEventStreamProcessContext(message3, waitHandle, versionList)));
-            processor.Process(new ProcessingEvent(message2, new DomainEventStreamProcessContext(message2, waitHandle, versionList)));
+            await processor.ProcessAsync(new ProcessingEvent(message1, new DomainEventStreamProcessContext(message1, waitHandle, versionList)));
+            await processor.ProcessAsync(new ProcessingEvent(message3, new DomainEventStreamProcessContext(message3, waitHandle, versionList)));
+            await processor.ProcessAsync(new ProcessingEvent(message2, new DomainEventStreamProcessContext(message2, waitHandle, versionList)));
 
             waitHandle.WaitOne();
 
@@ -670,7 +671,7 @@ namespace ENode.Tests
             }
         }
         [Test]
-        public void sequence_domain_event_process_test2()
+        public async Task sequence_domain_event_process_test2()
         {
             var processor = ObjectContainer.Resolve<IProcessingEventProcessor>();
 
@@ -690,8 +691,8 @@ namespace ENode.Tests
             var versionList = new List<int>();
 
             //模拟从publishedVersionStore中取到的publishedVersion不是最新的场景
-            processor.Process(new ProcessingEvent(message1, new DomainEventStreamProcessContext(message1, waitHandle, versionList)));
-            processor.Process(new ProcessingEvent(message3, new DomainEventStreamProcessContext(message3, waitHandle, versionList)));
+            await processor.ProcessAsync(new ProcessingEvent(message1, new DomainEventStreamProcessContext(message1, waitHandle, versionList)));
+            await processor.ProcessAsync(new ProcessingEvent(message3, new DomainEventStreamProcessContext(message3, waitHandle, versionList)));
 
             //等待5秒后更新publishedVersion为2
             Thread.Sleep(5000);

--- a/src/ENode/Commanding/ICommandProcessor.cs
+++ b/src/ENode/Commanding/ICommandProcessor.cs
@@ -1,4 +1,6 @@
-﻿namespace ENode.Commanding
+﻿using System.Threading.Tasks;
+
+namespace ENode.Commanding
 {
     /// <summary>Represents a processor to process command.
     /// </summary>
@@ -7,7 +9,7 @@
         /// <summary>Process the given command.
         /// </summary>
         /// <param name="processingCommand"></param>
-        void Process(ProcessingCommand processingCommand);
+        Task ProcessAsync(ProcessingCommand processingCommand);
         /// <summary>Start the processor.
         /// </summary>
         void Start();

--- a/src/ENode/Commanding/Impl/DefaultCommandProcessor.cs
+++ b/src/ENode/Commanding/Impl/DefaultCommandProcessor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using ECommon.Logging;
 using ECommon.Scheduling;
 using ENode.Configurations;
@@ -28,7 +29,7 @@ namespace ENode.Commanding.Impl
             _taskName = "CleanInactiveProcessingCommandMailBoxes_" + DateTime.Now.Ticks + new Random().Next(10000);
         }
 
-        public void Process(ProcessingCommand processingCommand)
+        public async Task ProcessAsync(ProcessingCommand processingCommand)
         {
             var aggregateRootId = processingCommand.Message.AggregateRootId;
             if (string.IsNullOrEmpty(aggregateRootId))
@@ -44,7 +45,8 @@ namespace ENode.Commanding.Impl
             var mailboxTryUsingCount = 0L;
             while (!mailbox.TryUsing())
             {
-                Thread.Sleep(1);
+                //todo: consider use Task.Yield() to release ThreadPool task thread.
+                await Task.Delay(1);
                 mailboxTryUsingCount++;
                 if (mailboxTryUsingCount % 10000 == 0)
                 {

--- a/src/ENode/Eventing/IProcessingEventProcessor.cs
+++ b/src/ENode/Eventing/IProcessingEventProcessor.cs
@@ -1,4 +1,6 @@
-﻿namespace ENode.Eventing
+﻿using System.Threading.Tasks;
+
+namespace ENode.Eventing
 {
     /// <summary>Represents a processor to process event.
     /// </summary>
@@ -10,7 +12,7 @@
         /// <summary>Process the given processingEvent.
         /// </summary>
         /// <param name="processingEvent"></param>
-        void Process(ProcessingEvent processingEvent);
+        Task ProcessAsync(ProcessingEvent processingEvent);
         /// <summary>Start the processor.
         /// </summary>
         void Start();

--- a/src/PerformanceTests/ENode.CommandProcessorPerfTests/Program.cs
+++ b/src/PerformanceTests/ENode.CommandProcessorPerfTests/Program.cs
@@ -35,7 +35,7 @@ namespace ENode.CommandProcessorPerfTests
         static int _totalCommandCount;
         static bool _isUpdating;
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             _commandCount = int.Parse(ConfigurationManager.AppSettings["count"]);
 
@@ -59,7 +59,7 @@ namespace ENode.CommandProcessorPerfTests
 
             _totalCommandCount = 1;
             _waitHandle = new ManualResetEvent(false);
-            _commandProcessor.Process(createCommand);
+            await _commandProcessor.ProcessAsync(createCommand);
             _waitHandle.WaitOne();
 
             _isUpdating = true;
@@ -70,11 +70,11 @@ namespace ENode.CommandProcessorPerfTests
             Console.WriteLine("");
             Console.WriteLine("--Start to update aggregate concurrently, total count: {0}.", _totalCommandCount);
 
-            Task.Factory.StartNew(() =>
+            await Task.Factory.StartNew(async () =>
             {
                 foreach (var updateCommand in updateCommands)
                 {
-                    _commandProcessor.Process(updateCommand);
+                    await _commandProcessor.ProcessAsync(updateCommand);
                 }
             });
 


### PR DESCRIPTION
由于GetAggregateRootLatestHandledEventVersion方法是异步方法，故修改ProcessingEventProcessor，CommandProcessor中的Process方法为异步，从而避免线程饥饿，死锁